### PR TITLE
Добавлено stylelint правило "selector-class-pattern"

### DIFF
--- a/stylelint/index.js
+++ b/stylelint/index.js
@@ -38,16 +38,6 @@ module.exports = {
         'unit-no-unknown': true,
         'no-duplicate-selectors': true,
         'declaration-block-no-duplicate-properties': true,
-        'selector-class-pattern': [
-            // '-' вне закона в css-классах
-            '^[^-]+$',
-            {
-                resolveNestedSelectors: true,
-                message:
-                    'Expected class selector to be camelCase (or, for corner cases, snake_case)',
-                severity: 'warning',
-            },
-        ],
 
         'stylelint-core-vars/use-vars': true,
         'stylelint-core-vars/use-mixins': true,
@@ -56,4 +46,21 @@ module.exports = {
         'stylelint-core-vars/do-not-use-dark-colors': [true, { severity: 'warning' }],
     },
     plugins: [require.resolve('@alfalab/stylelint-core-vars')],
+    overrides: [
+        {
+            files: ['*.module.css'],
+            rules: {
+                'selector-class-pattern': [
+                    // Запрещаем использовать дефис '-'
+                    '^[^-]+$',
+                    {
+                        resolveNestedSelectors: true,
+                        message:
+                            'Expected class selector to be camelCase (or, for corner cases, snake_case)',
+                        severity: 'warning',
+                    },
+                ],
+            },
+        },
+    ],
 };

--- a/stylelint/index.js
+++ b/stylelint/index.js
@@ -38,6 +38,16 @@ module.exports = {
         'unit-no-unknown': true,
         'no-duplicate-selectors': true,
         'declaration-block-no-duplicate-properties': true,
+        'selector-class-pattern': [
+            // '-' вне закона в css-классах
+            '^[^-]+$',
+            {
+                resolveNestedSelectors: true,
+                message:
+                    'Expected class selector to be camelCase (or, for corner cases, snake_case)',
+                severity: 'warning',
+            },
+        ],
 
         'stylelint-core-vars/use-vars': true,
         'stylelint-core-vars/use-mixins': true,

--- a/test/css-input.css
+++ b/test/css-input.css
@@ -4,7 +4,7 @@
 
 @custom-media --small-only screen and (max-width: 47.9375em);
 
-.superStyle {
+.super-style {
     display: flex;
 
     &__name {

--- a/test/css-input.css
+++ b/test/css-input.css
@@ -4,7 +4,7 @@
 
 @custom-media --small-only screen and (max-width: 47.9375em);
 
-.super-style {
+.superStyle {
     display: flex;
 
     &__name {

--- a/test/test.module.css
+++ b/test/test.module.css
@@ -1,0 +1,7 @@
+.testClass {
+    margin: 0;
+
+    &_inner {
+        padding: 0;
+    }
+}


### PR DESCRIPTION
Добавлено stylelint правило "selector-class-pattern"

## Мотивация и контекст

Наличие дефиса в классах:
1. Увеличивает размер css и js файла в распакованном виде
2. При создании алиасов в js, требует дополнительные кавычки
3. При некоторых настройках вебпака, в js ещё и создаётся копия алиаса в camelCase, вдобавок к пункту 2.

Не критично для резких исправлений, но при должном упорстве подсушивает вес сборки.