### PR TITLE
Добавлены stylelint правила "no-duplicate-selectors", "declaration-block-no-duplicate-properties"

### DIFF
--- a/stylelint/index.js
+++ b/stylelint/index.js
@@ -36,6 +36,8 @@ module.exports = {
         'shorthand-property-no-redundant-values': true,
         'string-no-newline': true,
         'unit-no-unknown': true,
+        'no-duplicate-selectors': true,
+        'declaration-block-no-duplicate-properties': true,
 
         'stylelint-core-vars/use-vars': true,
         'stylelint-core-vars/use-mixins': true,


### PR DESCRIPTION
Добавлены stylelint правила ["no-duplicate-selectors"](https://stylelint.io/user-guide/rules/declaration-block-no-duplicate-properties/), ["declaration-block-no-duplicate-properties"](https://stylelint.io/user-guide/rules/no-duplicate-selectors/)

## Мотивация и контекст

Часто на проектах в стили попадают лишние дубли правил, которые линтер никак не подсвечивает
