### PR TITLE
fix(stylelint): allow duplicate properties with different syntaxes

### DIFF
--- a/stylelint/index.js
+++ b/stylelint/index.js
@@ -37,7 +37,12 @@ module.exports = {
         'string-no-newline': true,
         'unit-no-unknown': true,
         'no-duplicate-selectors': true,
-        'declaration-block-no-duplicate-properties': true,
+        'declaration-block-no-duplicate-properties': [
+            true,
+            {
+                ignore: ['consecutive-duplicates-with-different-syntaxes'],
+            },
+        ],
 
         'stylelint-core-vars/use-vars': true,
         'stylelint-core-vars/use-mixins': true,

--- a/test/css-input.css
+++ b/test/css-input.css
@@ -10,6 +10,8 @@
     &__name {
         color: var(--red);
         width: calc(100px + 20px);
+        height: 100%;
+        height: 100vh;
         background: linear-gradient(
             0deg,
             rgba(0, 0, 0, 1) 80%,


### PR DESCRIPTION
Для правила ["declaration-block-no-duplicate-properties"](https://stylelint.io/user-guide/rules/no-duplicate-selectors/) разрешено дублировать [свойства с разным синтаксисом](https://stylelint.io/user-guide/rules/declaration-block-no-duplicate-properties/#ignore-consecutive-duplicates-with-different-syntaxes).

## Мотивация и контекст

Это необходимо чтобы иметь возможность писать фалбеки для свойств с новыми значениями, не поддерживаемыми в старых браузерах.