### PR TITLE
feat(stylelint): add ability to use pseudo class global

### DIFF
--- a/stylelint/index.js
+++ b/stylelint/index.js
@@ -28,7 +28,12 @@ module.exports = {
         'length-zero-no-unit': true,
         'no-empty-source': true,
         'no-invalid-double-slash-comments': true,
-        'selector-pseudo-class-no-unknown': true,
+        'selector-pseudo-class-no-unknown': [
+            true,
+            {
+                ignorePseudoClasses: ['global'],
+            },
+        ],
         'selector-pseudo-element-colon-notation': 'single',
         'selector-pseudo-element-no-unknown': true,
         'selector-type-case': 'lower',


### PR DESCRIPTION
Дать возможность использовать псевдо класс ":global"

## Мотивация и контекст

В наибольшем количестве проектов используются css модули, в которых бывает нужно переопределить внешние значения и для этого использовать псевдо класс ":global". 
В текущем решении приходится переписывать правило на запрет использовать неизвестные псевдо классы. 
Хочется чтобы это можно было делать без лишних манипуляция с правилами

[Issue в котором так же описал эту проблему](https://github.com/core-ds/arui-presets-lint/issues/34 )
