### PR TITLE
feat(*): update jsx-filename-extension rule

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -97,7 +97,7 @@ module.exports = {
         'react/jsx-props-no-spreading': 'off',
         'react/prefer-stateless-function': 'off',
         'react/destructuring-assignment': 'off',
-        'react/jsx-filename-extension': [1, { extensions: ['.jsx', '.tsx'] }],
+        'react/jsx-filename-extension': [1, { extensions: ['.jsx', '.tsx'], allow: 'as-needed' }],
         'react/jsx-one-expression-per-line': 'off',
         'react/function-component-definition': 'off',
 


### PR DESCRIPTION
### Обновление lint правила

- после изменения, будет разрешать использовать JSX только в файлах .tsx .jsx 

