### PR TITLE
fix(a11y): кнопки из core-components добавлены в настройки a11y

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -39,6 +39,19 @@ module.exports = {
         react: {
             version: 'detect',
         },
+        'jsx-a11y': {
+            components: {
+                Button: 'button',
+                IconButton: 'button',
+                PickerButton: 'button',
+                PickerButtonMobile: 'button',
+                PickerButtonDesktop: 'button',
+                ActionButton: 'button',
+                CustomButton: 'button',
+                CustomButtonDesktop: 'button',
+                CustomButtonMobile: 'button',
+            },
+        },
     },
     rules: {
         quotes: ['warn', 'single', { avoidEscape: true, allowTemplateLiterals: false }],


### PR DESCRIPTION
Добавление элементов из core-components в настройки a11y

## Мотивация и контекст

Сейчас все правила доступности для наших стандартных компонентов не отрабатывают. Исправляем это.

Результат:

<img width="1730" height="450" alt="CleanShot 2025-08-25 at 14 53 26@2x" src="https://github.com/user-attachments/assets/80ab242e-5628-4f6d-b2e1-8f5920aacad7" />

<img width="1158" height="224" alt="CleanShot 2025-08-25 at 14 53 47@2x" src="https://github.com/user-attachments/assets/7fd44528-7243-4d78-95d9-13bd2e2635cd" />

<img width="1164" height="186" alt="CleanShot 2025-08-25 at 14 54 14@2x" src="https://github.com/user-attachments/assets/119519f7-2ebc-4a49-bef8-34f8f76ff763" />

