### PR TITLE
fix slow work import-x/no-cycle

### DIFF
--- a/.changeset/tiny-memes-beg.md
+++ b/.changeset/tiny-memes-beg.md
@@ -1,0 +1,5 @@
+---
+'arui-presets-lint': patch
+---
+
+Для правила import-x/no-cycle задан maxDepth вместе с ignoreExternal, чтобы снизить время линта на больших графах импортов. В V9_MIGRATION_GUIDE описан компромисс и как переопределить правило в проекте

--- a/packages/arui-presets-lint/V9_MIGRATION_GUIDE.md
+++ b/packages/arui-presets-lint/V9_MIGRATION_GUIDE.md
@@ -78,6 +78,23 @@ export default defineConfig(eslintConfig, [
 
     Так же все правила в конфиге которые начинаються на `import/` нужно заменить на `import-x/`. Других изменений делать не нужно, новый плагин полностью совместим со старым.
 
+    **Производительность `import-x/no-cycle`.**
+    Правило «дорогое»: оно обходит зависимости, чтобы найти путь обратно к текущему файлу.
+    В пресете это задано в [`eslint/rules/imports.ts`](eslint/rules/imports.ts): по умолчанию включены **`ignoreExternal: true`** и **`maxDepth: 20`** (см. [документацию правила](https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-cycle.md)). Циклы длиннее этого порога ESLint не сообщит.
+    Если необходима проверка без ограничения глубины или другое значение, то переопределите правило в своём `eslint.config.mts`:
+
+    ```typescript
+    {
+        rules: {
+            'import-x/no-cycle': ['error', { ignoreExternal: true, maxDepth: 50 }],
+            // или полная проверка без maxDepth (может сильно увеличить время линта):
+            // 'import-x/no-cycle': ['error', { ignoreExternal: true }],
+            // или отключить правило:
+            // 'import-x/no-cycle': 'off',
+        },
+    },
+    ```
+
 4. Набор правил eslint изменился - но многие правятся с помощью автофикса. Сделаем это!
 
     ```bash

--- a/packages/arui-presets-lint/eslint/rules/imports.ts
+++ b/packages/arui-presets-lint/eslint/rules/imports.ts
@@ -196,7 +196,8 @@ export const importsConfig: Linter.Config = {
 
         // Запрещать циклические зависимости между модулями
         // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-cycle.md
-        'import-x/no-cycle': ['error', { ignoreExternal: true }],
+        // maxDepth ограничивает глубину обхода графа импортов (без лимита правило сильно замедляет линтинг на больших проектах)
+        'import-x/no-cycle': ['error', { ignoreExternal: true, maxDepth: 20 }],
 
         // Гарантировать отсутствие бесполезных сегментов пути
         // https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-useless-path-segments.md


### PR DESCRIPTION
Ограничена глубина проверки import-x/no-cycle - maxDepth, для ускорения проверок eslint

## Мотивация и контекст

https://github.com/core-ds/arui-presets-lint/issues/96
