### PR TITLE
feat(*): add new typescript-eslint rules

### DIFF
--- a/.changeset/floppy-bikes-joke.md
+++ b/.changeset/floppy-bikes-joke.md
@@ -1,0 +1,7 @@
+---
+'arui-presets-lint': minor
+---
+
+Добавлены новые правила typescript-eslint:
+`@typescript-eslint/no-duplicate-enum-values` - запрещает дублирование значений в enum
+`@typescript-eslint/prefer-optional-chain` - требует использования optional chaining вместо цепочек условий

--- a/packages/arui-presets-lint/eslint/rules/typescript.ts
+++ b/packages/arui-presets-lint/eslint/rules/typescript.ts
@@ -176,6 +176,14 @@ export const typescriptConfig: Linter.Config = {
         'default-param-last': 'off',
         '@typescript-eslint/default-param-last': bestPracticesRules['default-param-last'],
 
+        // Запрещает дублирование значений в enum
+        // https://typescript-eslint.io/rules/no-duplicate-enum-values
+        '@typescript-eslint/no-duplicate-enum-values': 'error',
+
+        // Требует использования optional chaining вместо цепочек условий
+        // https://typescript-eslint.io/rules/prefer-optional-chain
+        '@typescript-eslint/prefer-optional-chain': 'error',
+
         // Требует/запрещает инициализацию переменных при объявлении
         // https://eslint.org/docs/rules/init-declarations
         'init-declarations': 'off',

--- a/packages/stylelint-core-vars/lib/index.ts
+++ b/packages/stylelint-core-vars/lib/index.ts
@@ -167,7 +167,7 @@ const checkTypography = (
 
     const foundMixins = findTypographyMixins(typographyProps);
 
-    if (!foundMixins || !foundMixins.length) return;
+    if (!foundMixins?.length) return;
 
     const exactMixin = foundMixins.length === 1;
 

--- a/packages/stylelint-core-vars/lib/utils.ts
+++ b/packages/stylelint-core-vars/lib/utils.ts
@@ -243,7 +243,7 @@ export function findVars(
     for (const [value, variables] of Object.entries(propVars)) {
         const chosen = choiceVars(variables, prop, group);
 
-        if (!chosen || !chosen.length) continue;
+        if (!chosen?.length) continue;
 
         const index = findSubstring(cssValue, value);
 


### PR DESCRIPTION
Новые правила для eslint

## Мотивация и контекст

`@typescript-eslint/prefer-optional-chain` 
замена громоздких проверок на более чистый синтаксис

`@typescript-eslint/no-duplicate-enum-values` 
запрещает дублировать значения в enum, чтобы избежать неожиданного поведения