### PR TITLE
fix(arui-presets-lint): добавил default в exports для резолва commitlint

### DIFF
--- a/.changeset/spicy-symbols-grab.md
+++ b/.changeset/spicy-symbols-grab.md
@@ -1,0 +1,6 @@
+
+---
+'arui-presets-lint': patch
+---
+
+В dist `exports` для subpath (в том числе `arui-presets-lint/commitlint`) добавлено условие `default`, чтобы CJS-резолверы (`require.resolve`, `resolve-from`) находили модуль

--- a/packages/arui-presets-lint/_internal/build-dist-package.ts
+++ b/packages/arui-presets-lint/_internal/build-dist-package.ts
@@ -5,23 +5,56 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-type ExportTarget = string | { types: string; import: string };
+type ExportConditions = {
+    types?: string;
+    import?: string;
+    require?: string;
+    default?: string;
+};
+type ExportTarget = string | ExportConditions;
 type Deps = Record<string, string>;
 type PackageJson = { exports: Record<string, ExportTarget>; [key: string]: unknown };
 
 const sourcePkg = JSON.parse(await readFile('package.json', 'utf8')) as PackageJson;
 
-const distExports = Object.fromEntries(
-    Object.entries(sourcePkg.exports).map(([subpath, target]): [string, ExportTarget] => {
-        if (typeof target !== 'string' || !target.endsWith('.ts')) {
-            return [subpath, target];
+/**
+ * Добавляем `default` (тот же ESM-файл, что и `import`) только для resolve:
+ * CJS резолверы вроде require.resolve / resolve-from иначе не находят subpath
+ * (например arui-presets-lint/commitlint).
+ */
+const withResolvableConditions = (jsTarget: string, dtsTarget: string): ExportConditions => ({
+    types: dtsTarget,
+    import: jsTarget,
+    default: jsTarget,
+});
+
+const toDistExport = (target: ExportTarget): ExportTarget => {
+    if (typeof target === 'string') {
+        if (!target.endsWith('.ts')) {
+            return target;
         }
 
         const jsTarget = target.replace(/\.ts$/, '.js');
         const dtsTarget = target.replace(/\.ts$/, '.d.ts');
 
-        return [subpath, { types: dtsTarget, import: jsTarget }];
-    }),
+        return withResolvableConditions(jsTarget, dtsTarget);
+    }
+
+    if (target.import && !target.default) {
+        return {
+            ...target,
+            default: target.import,
+        };
+    }
+
+    return target;
+};
+
+const distExports = Object.fromEntries(
+    Object.entries(sourcePkg.exports).map(([subpath, target]): [string, ExportTarget] => [
+        subpath,
+        toDistExport(target),
+    ]),
 );
 
 async function resolveWorkspaceDeps(deps: Deps | undefined): Promise<Deps | undefined> {

--- a/packages/arui-presets-lint/commitlint/README.md
+++ b/packages/arui-presets-lint/commitlint/README.md
@@ -1,0 +1,16 @@
+# commitlint
+
+Базовый конфиг: `@commitlint/config-conventional` + обязательный `scope` и лимит длины body.
+
+## Подключение
+
+```js
+// commitlint.config.mjs
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+export default {
+    extends: [require.resolve('arui-presets-lint/commitlint')],
+};
+```

--- a/packages/arui-presets-lint/package.json
+++ b/packages/arui-presets-lint/package.json
@@ -76,10 +76,7 @@
         "./eslint/config": "./eslint/config.ts",
         "./eslint/rules": "./eslint/rules/index.ts",
         "./eslint/plugins": "./eslint/plugins/index.ts",
-        "./prettier": {
-            "types": "./prettier/index.d.ts",
-            "import": "./prettier/index.js"
-        },
+        "./prettier": "./prettier/index.ts",
         "./commitlint": "./commitlint/index.ts",
         "./stylelint": "./stylelint/index.ts"
     },


### PR DESCRIPTION
добавил default в exports для резолва commitlint
Хочу в проекте ссылаться на базовый конфиг arui-presets-lint/commitlint

В dist exports для subpath (и для arui-presets-lint/commitlint) было только условие import, 
поэтому require.resolve не находил модуль