### PR TITLE
fix(arui-presets-lint): disable eslint cache for markdown hooks

### DIFF
--- a/.changeset/curly-cats-rest.md
+++ b/.changeset/curly-cats-rest.md
@@ -1,0 +1,5 @@
+---
+'arui-presets-lint': patch
+---
+
+В Lefthook-пресете отключён ESLint cache для Markdown-файлов, чтобы хуки не создавали `.eslintcache` в корне проекта.

--- a/packages/arui-presets-lint/lefthook/index.yml
+++ b/packages/arui-presets-lint/lefthook/index.yml
@@ -14,7 +14,7 @@ pre-commit:
             stage_fixed: true
         check-md:
             glob: '*.{md}'
-            run: npx --no-install eslint {staged_files} --cache --no-warn-ignored
+            run: npx --no-install eslint {staged_files} --no-warn-ignored
         check-secrets:
             run: npx --no-install secretlint {staged_files}
 pre-push:
@@ -28,7 +28,7 @@ pre-push:
             run: npx --no-install prettier --check {push_files} --cache && npx --no-install stylelint {push_files} --allow-empty-input --cache --cache-location="./node_modules/.cache/stylelint/.stylelintcache"
         check-md:
             glob: '*.{md}'
-            run: npx --no-install eslint {push_files} --cache --no-warn-ignored
+            run: npx --no-install eslint {push_files} --no-warn-ignored
         check-secrets:
             run: npx --no-install secretlint {push_files}
 commit-msg:

--- a/packages/arui-presets-lint/test/__snapshots__/configs.test.ts.snap
+++ b/packages/arui-presets-lint/test/__snapshots__/configs.test.ts.snap
@@ -9257,6 +9257,47 @@ exports[`статические конфиги > knip 1`] = `
 }
 `;
 
+exports[`статические конфиги > lefthook 1`] = `
+"#   Описание параметров тут:
+#   https://lefthook.dev/configuration/
+
+pre-commit:
+    parallel: true
+    commands:
+        check-scripts:
+            glob: '*.{js,ts,jsx,tsx,mts,mjs,cjs,cts,ctsx,mtsx,cjsx,mjsx,json,json5,jsonc}'
+            run: npx --no-install prettier --write {staged_files} --cache && npx --no-install eslint {staged_files} --no-warn-ignored
+            stage_fixed: true
+        check-styles:
+            glob: '*.{css}'
+            run: npx --no-install prettier --write {staged_files} --cache && npx --no-install stylelint {staged_files} --allow-empty-input --cache --cache-location="./node_modules/.cache/stylelint/.stylelintcache"
+            stage_fixed: true
+        check-md:
+            glob: '*.{md}'
+            run: npx --no-install eslint {staged_files} --no-warn-ignored
+        check-secrets:
+            run: npx --no-install secretlint {staged_files}
+pre-push:
+    parallel: true
+    commands:
+        check-scripts:
+            glob: '*.{js,ts,jsx,tsx,mts,mjs,cjs,cts,ctsx,mtsx,cjsx,mjsx,json,json5,jsonc}'
+            run: npx --no-install prettier --check {push_files} --cache && npx --no-install eslint {push_files} --no-warn-ignored
+        check-styles:
+            glob: '*.{css}'
+            run: npx --no-install prettier --check {push_files} --cache && npx --no-install stylelint {push_files} --allow-empty-input --cache --cache-location="./node_modules/.cache/stylelint/.stylelintcache"
+        check-md:
+            glob: '*.{md}'
+            run: npx --no-install eslint {push_files} --no-warn-ignored
+        check-secrets:
+            run: npx --no-install secretlint {push_files}
+commit-msg:
+    commands:
+        commitlint:
+            run: npx --no-install commitlint --edit {1}
+"
+`;
+
 exports[`статические конфиги > prettier 1`] = `
 {
   "endOfLine": "auto",

--- a/packages/arui-presets-lint/test/configs.test.ts
+++ b/packages/arui-presets-lint/test/configs.test.ts
@@ -1,4 +1,5 @@
 import { ESLint, type Linter } from 'eslint';
+import fs from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
@@ -83,5 +84,11 @@ describe('статические конфиги', () => {
 
     it('knip', () => {
         expectToMatchSnapshot(knipConfig);
+    });
+
+    it('lefthook', () => {
+        expectToMatchSnapshot(
+            fs.readFileSync(path.join(packageRoot, 'lefthook/index.yml'), 'utf8'),
+        );
     });
 });


### PR DESCRIPTION
## Мотивация и контекст

Markdown-команды Lefthook запускали ESLint с `--cache` без `--cache-location`. Из-за этого pre-commit и pre-push создавали `.eslintcache` в корне проекта, хотя для остальных ESLint-команд cache отключён.

<img width="1033" height="328" alt="image" src="https://github.com/user-attachments/assets/d275831f-a0c7-4709-a5b2-37738e3167cb" />

