### PR TITLE
feat(mobile-index-for-knip): Добавлена поддержка `mobile-index` в стандартных точках входа Knip.

### DIFF
--- a/.changeset/nasty-bobcats-invent.md
+++ b/.changeset/nasty-bobcats-invent.md
@@ -1,0 +1,5 @@
+---
+'arui-presets-lint': patch
+---
+
+Добавлена поддержка `mobile-index` в стандартных точках входа Knip.

--- a/packages/arui-presets-lint/knip/index.ts
+++ b/packages/arui-presets-lint/knip/index.ts
@@ -22,8 +22,8 @@ export default {
         // Стандартные точки входа knip. При переопределении опции entry дефолтные значения
         // не объединяются с заданными, поэтому повторяем их явно
         // https://knip.dev/overview/configuration#defaults
-        '{index,cli,main}.{js,mjs,cjs,jsx,ts,tsx,mts,cts}!',
-        'src/{index,cli,main}.{js,mjs,cjs,jsx,ts,tsx,mts,cts}!',
+        '{index,mobile-index,cli,main}.{js,mjs,cjs,jsx,ts,tsx,mts,cts}!',
+        'src/{index,mobile-index,cli,main}.{js,mjs,cjs,jsx,ts,tsx,mts,cts}!',
         // Серверная точка входа приложений arui-scripts и совместимых сборщиков
         // ({,app/} - поддержка обеих структур проекта: базовой и feature-sliced)
         'src/{,app/}server/index.{js,jsx,ts,tsx}!',

--- a/packages/arui-presets-lint/test/__snapshots__/configs.test.ts.snap
+++ b/packages/arui-presets-lint/test/__snapshots__/configs.test.ts.snap
@@ -9219,8 +9219,8 @@ exports[`статические конфиги > knip 1`] = `
   "commitlint": false,
   "cypress": true,
   "entry": [
-    "{index,cli,main}.{js,mjs,cjs,jsx,ts,tsx,mts,cts}!",
-    "src/{index,cli,main}.{js,mjs,cjs,jsx,ts,tsx,mts,cts}!",
+    "{index,mobile-index,cli,main}.{js,mjs,cjs,jsx,ts,tsx,mts,cts}!",
+    "src/{index,mobile-index,cli,main}.{js,mjs,cjs,jsx,ts,tsx,mts,cts}!",
     "src/{,app/}server/index.{js,jsx,ts,tsx}!",
     "src/server/{mock,mocks}/**/*.{js,ts}",
     "src/modules/**/*.{js,jsx,ts,tsx}!",


### PR DESCRIPTION
Добавлена поддержка `mobile-index` в стандартных точках входа Knip.

Ранее стандартная конфигурация Knip учитывала только точки входа `index`, `cli` и `main`. В проектах, использующих отдельную точку входа `mobile-index`, такие файлы не попадали в анализ, из-за чего Knip мог некорректно определять используемые зависимости и экспортируемые сущности.

В рамках изменений `mobile-index` добавлен в список стандартных точек входа, благодаря чему мобильные точки входа анализируются автоматически без необходимости переопределять конфигурацию Knip в каждом проекте.