### PR TITLE
Перевод правила `react/jsx-no-useless-fragment` с режима ошибки на конфигурацию с `allowExpressions: true`.

### DIFF
--- a/.changeset/wide-sites-grin.md
+++ b/.changeset/wide-sites-grin.md
@@ -1,0 +1,5 @@
+---
+'arui-presets-lint': patch
+---
+
+- Для правила react/jsx-no-useless-fragment добавлено исключение в виде одиночных выражений

--- a/packages/arui-presets-lint/eslint/rules/react.ts
+++ b/packages/arui-presets-lint/eslint/rules/react.ts
@@ -417,9 +417,14 @@ export const reactConfig: Linter.Config = {
             ],
         ],
 
-        // Запрещает ненужные фрагменты
+        // Запрещает ненужные фрагменты, но разрешает одиночные выражения в них
         // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-useless-fragment.md
-        'react/jsx-no-useless-fragment': 'error',
+        'react/jsx-no-useless-fragment': [
+            'error',
+            {
+                allowExpressions: true,
+            },
+        ],
 
         // Обязывает конкретный тип функции для функциональных компонентов
         // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/function-component-definition.md

--- a/packages/arui-presets-lint/test/__snapshots__/configs.test.ts.snap
+++ b/packages/arui-presets-lint/test/__snapshots__/configs.test.ts.snap
@@ -3920,6 +3920,9 @@ exports[`итоговый резолв конфига eslint > src/components/so
   ],
   "react/jsx-no-useless-fragment": [
     2,
+    {
+      "allowExpressions": true,
+    },
   ],
   "react/jsx-one-expression-per-line": [
     0,


### PR DESCRIPTION
## Мотивация и контекст

Правило `react/jsx-no-useless-fragment` было переведено с режима ошибки на конфигурацию с `allowExpressions: true`.

Изменение необходимо, потому что в строгом режиме правило ошибочно помечает фрагменты, содержащие единственное выражение (например, `<Fragment>{items.length}</Fragment>`), как лишние. Однако такие фрагменты могут требоваться для корректной работы React Children API, CSS-селекторов соседей (`& + &`, `& ~ &`) или для явного возврата выражения там, где возврат React-узла обязателен (например, в `render`-пропсах и некоторых HOC-паттернах).

`allowExpressions: true` разрешает фрагменты с одним expression-узлом, сохраняя строгую проверку для всех остальных случаев (пустые фрагменты, вложенные фрагменты с одним элементом и т.д.).


У нас в коде много где используется, один из примеров: 
<img width="901" height="667" alt="image" src="https://github.com/user-attachments/assets/a23fe542-40e6-434d-af97-06b177e0580b" />

по поиску в проектах ,можно найти очень много отключения правила в текущем ввиде
// eslint-disable-next-line react/jsx-no-useless-fragment
