### PR TITLE
Правила react-hooks включены для всех скриптов

### DIFF
--- a/.changeset/fix-react-hooks-typescript.md
+++ b/.changeset/fix-react-hooks-typescript.md
@@ -1,0 +1,5 @@
+---
+'arui-presets-lint': patch
+---
+
+Правила React Hooks теперь проверяются во всех поддерживаемых JavaScript- и TypeScript-файлах.

--- a/packages/arui-presets-lint/_internal/duplicates-checker.ts
+++ b/packages/arui-presets-lint/_internal/duplicates-checker.ts
@@ -7,6 +7,7 @@ import { markdownConfig } from '../eslint/rules/markdown.js';
 import { nodeRulesConfig } from '../eslint/rules/node.js';
 import { reactConfig } from '../eslint/rules/react.js';
 import { reactA11yConfig } from '../eslint/rules/react-a11y.js';
+import { reactHooksConfig } from '../eslint/rules/react-hooks.js';
 import { testsConfig } from '../eslint/rules/tests.js';
 import { typescriptConfig } from '../eslint/rules/typescript.js';
 import { variablesConfig } from '../eslint/rules/variables.js';
@@ -15,6 +16,10 @@ const imports = { rules: Object.keys(importsConfig.rules || {}), name: importsCo
 const node = { rules: Object.keys(nodeRulesConfig.rules || {}), name: nodeRulesConfig.name };
 const react = { rules: Object.keys(reactConfig.rules || {}), name: reactConfig.name };
 const reactA11y = { rules: Object.keys(reactA11yConfig.rules || {}), name: reactA11yConfig.name };
+const reactHooks = {
+    rules: Object.keys(reactHooksConfig.rules || {}),
+    name: reactHooksConfig.name,
+};
 const tests = { rules: Object.keys(testsConfig.rules || {}), name: testsConfig.name };
 const typescript = {
     rules: Object.keys(typescriptConfig.rules || {}),
@@ -79,6 +84,7 @@ const configs: Array<{
     node,
     react,
     reactA11y,
+    reactHooks,
     tests,
     typescript,
     variables,

--- a/packages/arui-presets-lint/eslint/index.ts
+++ b/packages/arui-presets-lint/eslint/index.ts
@@ -27,6 +27,7 @@ import {
     nodeRulesConfig,
     reactA11yConfig,
     reactConfig,
+    reactHooksConfig,
     testsConfig,
     typescriptConfig,
     variablesConfig,
@@ -96,6 +97,7 @@ export const eslintConfig = [
     */
     bestPracticesConfig,
     nodeRulesConfig,
+    reactHooksConfig,
     reactConfig,
     reactA11yConfig,
     variablesConfig,

--- a/packages/arui-presets-lint/eslint/rules.ts
+++ b/packages/arui-presets-lint/eslint/rules.ts
@@ -5,6 +5,7 @@ export {
     markdownConfig,
     nodeRulesConfig,
     reactA11yConfig,
+    reactHooksConfig,
     reactConfig,
     testsConfig,
     typescriptConfig,

--- a/packages/arui-presets-lint/eslint/rules/index.ts
+++ b/packages/arui-presets-lint/eslint/rules/index.ts
@@ -4,6 +4,7 @@ export { jsonConfig } from './json.js';
 export { markdownConfig } from './markdown.js';
 export { nodeRulesConfig } from './node.js';
 export { reactA11yConfig } from './react-a11y.js';
+export { reactHooksConfig } from './react-hooks.js';
 export { reactConfig } from './react.js';
 export { testsConfig } from './tests.js';
 export { typescriptConfig } from './typescript.js';

--- a/packages/arui-presets-lint/eslint/rules/react-hooks.ts
+++ b/packages/arui-presets-lint/eslint/rules/react-hooks.ts
@@ -1,0 +1,26 @@
+import { type Linter } from 'eslint';
+import reactHooksPlugin from 'eslint-plugin-react-hooks';
+
+import { GLOBAL_SCRIPTS_SCOPE } from '../constants.js';
+
+export const reactHooksConfig: Linter.Config = {
+    ...reactHooksPlugin.configs.flat['recommended-latest'],
+
+    name: 'arui-presets-lint/react-hooks',
+    files: [GLOBAL_SCRIPTS_SCOPE],
+    plugins: {
+        'react-hooks': reactHooksPlugin,
+    } as Linter.Config['plugins'],
+
+    rules: {
+        ...reactHooksPlugin.configs.flat['recommended-latest'].rules,
+
+        // Правила хуков (обязательные)
+        // https://react.dev/reference/rules/rules-of-hooks
+        'react-hooks/rules-of-hooks': 'error',
+
+        // Проверка списка зависимостей для хуков типа useEffect и др.
+        // https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks#advanced-configuration
+        'react-hooks/exhaustive-deps': 'error',
+    },
+};

--- a/packages/arui-presets-lint/eslint/rules/react.ts
+++ b/packages/arui-presets-lint/eslint/rules/react.ts
@@ -1,21 +1,18 @@
 import { type Linter } from 'eslint';
 import reactPlugin from 'eslint-plugin-react';
-import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import reactYouMightNotNeedAnEffectPlugin from 'eslint-plugin-react-you-might-not-need-an-effect';
 
 import { REACT_SCRIPTS_SCOPE } from '../constants.js';
 
 export const reactConfig: Linter.Config = {
     ...reactPlugin.configs.flat.recommended,
-    ...reactHooksPlugin.configs['recommended-latest'],
 
     name: 'arui-presets-lint/react',
     files: [REACT_SCRIPTS_SCOPE],
     plugins: {
         react: reactPlugin,
-        'react-hooks': reactHooksPlugin,
         'react-you-might-not-need-an-effect': reactYouMightNotNeedAnEffectPlugin,
-    } as Linter.Config['plugins'],
+    },
 
     settings: {
         react: {
@@ -27,8 +24,6 @@ export const reactConfig: Linter.Config = {
     rules: {
         // https://github.com/jsx-eslint/eslint-plugin-react?tab=readme-ov-file#list-of-supported-rules
         ...reactPlugin.configs.flat.recommended.rules,
-
-        ...reactHooksPlugin.configs['recommended-latest'].rules,
 
         // Эвристики поиска лишних useEffect: derived state, цепочки обновлений state,
         // логика обработчиков событий в эффектах и т.д. Все правила рекомендованного
@@ -461,14 +456,6 @@ export const reactConfig: Linter.Config = {
         // Предотвращает объявление неиспользуемых методов класса компонента
         // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-class-component-methods.md
         'react/no-unused-class-component-methods': 'error',
-
-        // Правила хуков (обязательные)
-        // https://react.dev/reference/rules/rules-of-hooks
-        'react-hooks/rules-of-hooks': 'error',
-
-        // Проверка списка зависимостей для хуков типа useEffect и др.
-        // https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks#advanced-configuration
-        'react-hooks/exhaustive-deps': 'error',
 
         // Определяет, где должны располагаться статические свойства компонента React
         // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/static-property-placement.md

--- a/packages/arui-presets-lint/test/__snapshots__/configs.test.ts.snap
+++ b/packages/arui-presets-lint/test/__snapshots__/configs.test.ts.snap
@@ -1252,6 +1252,57 @@ exports[`итоговый резолв конфига eslint > scripts/build.mjs
     2,
     "always",
   ],
+  "react-hooks/config": [
+    2,
+  ],
+  "react-hooks/error-boundaries": [
+    2,
+  ],
+  "react-hooks/exhaustive-deps": [
+    2,
+  ],
+  "react-hooks/gating": [
+    2,
+  ],
+  "react-hooks/globals": [
+    2,
+  ],
+  "react-hooks/immutability": [
+    2,
+  ],
+  "react-hooks/incompatible-library": [
+    1,
+  ],
+  "react-hooks/preserve-manual-memoization": [
+    2,
+  ],
+  "react-hooks/purity": [
+    2,
+  ],
+  "react-hooks/refs": [
+    2,
+  ],
+  "react-hooks/rules-of-hooks": [
+    2,
+  ],
+  "react-hooks/set-state-in-effect": [
+    2,
+  ],
+  "react-hooks/set-state-in-render": [
+    2,
+  ],
+  "react-hooks/static-components": [
+    2,
+  ],
+  "react-hooks/unsupported-syntax": [
+    1,
+  ],
+  "react-hooks/use-memo": [
+    2,
+  ],
+  "react-hooks/void-use-memo": [
+    2,
+  ],
   "require-atomic-updates": [
     0,
     {
@@ -6237,6 +6288,57 @@ exports[`итоговый резолв конфига eslint > src/utils/helpers
     2,
     "always",
   ],
+  "react-hooks/config": [
+    2,
+  ],
+  "react-hooks/error-boundaries": [
+    2,
+  ],
+  "react-hooks/exhaustive-deps": [
+    2,
+  ],
+  "react-hooks/gating": [
+    2,
+  ],
+  "react-hooks/globals": [
+    2,
+  ],
+  "react-hooks/immutability": [
+    2,
+  ],
+  "react-hooks/incompatible-library": [
+    1,
+  ],
+  "react-hooks/preserve-manual-memoization": [
+    2,
+  ],
+  "react-hooks/purity": [
+    2,
+  ],
+  "react-hooks/refs": [
+    2,
+  ],
+  "react-hooks/rules-of-hooks": [
+    2,
+  ],
+  "react-hooks/set-state-in-effect": [
+    2,
+  ],
+  "react-hooks/set-state-in-render": [
+    2,
+  ],
+  "react-hooks/static-components": [
+    2,
+  ],
+  "react-hooks/unsupported-syntax": [
+    1,
+  ],
+  "react-hooks/use-memo": [
+    2,
+  ],
+  "react-hooks/void-use-memo": [
+    2,
+  ],
   "require-atomic-updates": [
     0,
     {
@@ -8393,6 +8495,57 @@ exports[`итоговый резолв конфига eslint > src/utils/helpers
   "radix": [
     2,
     "always",
+  ],
+  "react-hooks/config": [
+    2,
+  ],
+  "react-hooks/error-boundaries": [
+    2,
+  ],
+  "react-hooks/exhaustive-deps": [
+    2,
+  ],
+  "react-hooks/gating": [
+    2,
+  ],
+  "react-hooks/globals": [
+    2,
+  ],
+  "react-hooks/immutability": [
+    2,
+  ],
+  "react-hooks/incompatible-library": [
+    1,
+  ],
+  "react-hooks/preserve-manual-memoization": [
+    2,
+  ],
+  "react-hooks/purity": [
+    2,
+  ],
+  "react-hooks/refs": [
+    2,
+  ],
+  "react-hooks/rules-of-hooks": [
+    2,
+  ],
+  "react-hooks/set-state-in-effect": [
+    2,
+  ],
+  "react-hooks/set-state-in-render": [
+    2,
+  ],
+  "react-hooks/static-components": [
+    2,
+  ],
+  "react-hooks/unsupported-syntax": [
+    1,
+  ],
+  "react-hooks/use-memo": [
+    2,
+  ],
+  "react-hooks/void-use-memo": [
+    2,
   ],
   "require-atomic-updates": [
     0,


### PR DESCRIPTION
## Мотивация и контекст

Сейчас хуки, которые лежат в файлах с расширением .ts не проверяются eslint-ом. Исправляем это.